### PR TITLE
Go1.16

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,19 @@ Or, if you have the Golang toolchain installed :
 go get github.com/ShimmerGlass/bar3x
 ```
 
+### Building
+
+Building bar3x requires [Go](https://golang.org) and [go-bindata](https://github.com/jteeuwen/go-bindata).  go-bindata is go-get-able:
+
+```
+go get github.com/jteeuwen/go-bindata
+git clone github.com/ShimmerGlass/bar3x
+cd bar3x
+go generate
+go build .
+# Copy ./bar3x to a directory in your $PATH
+```
+
 ### Dependencies
 
 - [libcairo](https://www.cairographics.org/) : should already installed as it is used by GTK, otherwise:

--- a/config.go
+++ b/config.go
@@ -1,7 +1,7 @@
-//go:generate go-bindata resources/...
 package main
 
 import (
+	"embed"
 	"encoding/base64"
 	"fmt"
 	"io/ioutil"
@@ -14,8 +14,11 @@ import (
 
 var defaultCtx ui.Context
 
+//go:embed resources/*
+var assets embed.FS
+
 func mustB64Asset(path string) string {
-	data, err := Asset(path)
+	data, err := assets.ReadFile(path)
 	if err != nil {
 		log.Fatalf("could not open embeded asset %s: %s", path, err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/shimmerglass/bar3x
 
-go 1.14
+go 1.16
 
 require (
 	github.com/BurntSushi/freetype-go v0.0.0-20160129220410-b763ddbfe298 // indirect


### PR DESCRIPTION
This PR replaces the go:generate and the dependency on go-bindata with Go 1.16's new `embed` feature.  This removes the need to either (a) commit `bindata.go` to allow `go get`ting, or (b) require users to install go-bindata, check out the project, and run `go generate` themselves before they can build.

This change does require building with Go >= 1.16.