### PR TITLE
network interface priorities

### DIFF
--- a/lib/bandwidth/bandwidth.go
+++ b/lib/bandwidth/bandwidth.go
@@ -103,3 +103,24 @@ func readBandwidth(dev string) (int, int, error) {
 
 	return 0, 0, fmt.Errorf("dev \"%s\" not found", dev)
 }
+
+
+func IsValidInterface (dev string) bool {
+	lines, err := readLines("/proc/net/dev")
+	if err != nil {
+		return false
+	}
+
+	for _, line := range lines {
+		fields := strings.Split(line, ":")
+		if len(fields) < 2 {
+			continue
+		}
+		key := strings.TrimSpace(fields[0])
+		if key == dev {
+			return true
+		}
+	}
+
+	return false
+}

--- a/ui/module/interface.go
+++ b/ui/module/interface.go
@@ -2,6 +2,7 @@ package module
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -79,8 +80,20 @@ func (m *Interface) Iface() string {
 	return m.iface
 }
 func (m *Interface) SetIface(s string) {
-	m.iface = s
-	m.bw = bandwidth.New(s)
+	var interfaces []string
+	if strings.Contains(s, ",") {
+		interfaces = strings.Split(s, ",")
+	} else {
+		interfaces = []string{s}
+	}
+
+	for _, iface := range interfaces {
+		if bandwidth.IsValidInterface(iface) {
+			m.iface = iface
+			m.bw = bandwidth.New(iface)
+			return
+		}
+	}
 }
 
 func (m *Interface) ShowLabel() bool {


### PR DESCRIPTION
This will allow comma separated interface names. the first valid interface will be used.